### PR TITLE
Update README to include gem requirement

### DIFF
--- a/README
+++ b/README
@@ -3,8 +3,10 @@ Redis Sampler README
 
 Redis sampler is an utility to check the composition of your Redis dataset.
 
-Using it is as simple as typing:
+Using it is as requires an install of redis:
+    gem install redis
 
+Then running it is as simple as:
     ./redis-sampler.rb <host> <port> <db> <samplesize>
 
 The host and port arguments are the ones of your Redis instance.


### PR DESCRIPTION
Closes #3 

Whilst likely obvious to people from the error thrown:
```
Traceback (most recent call last):
        2: from ./redis-sampler.rb:31:in `<main>'
        1: from /usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb:85:in `require'
/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb:85:in `require': cannot load such file -- redis (LoadError)
```
seemed worth calling out the specific install required. 